### PR TITLE
Add example notebook for LLM agent deployment with tool calling via ALCF endpoint

### DIFF
--- a/endpoint_agents_demo.ipynb
+++ b/endpoint_agents_demo.ipynb
@@ -1,0 +1,243 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3c597201-1559-4825-b34d-bea53dc31d99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture --no-stderr\n",
+    "%pip install -U langgraph langchain-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3e49f6ec-f4d9-418d-bd37-4661e41293bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully loaded model: meta-llama/Llama-3.3-70B-Instruct from https://data-portal-dev.cels.anl.gov/resource_server/sophia/vllm/v1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from inference_auth_token import get_access_token\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "access_token = get_access_token()\n",
+    "base_url=\"https://data-portal-dev.cels.anl.gov/resource_server/sophia/vllm/v1\"\n",
+    "#model ='meta-llama/Meta-Llama-3.1-405B-Instruct'\n",
+    "model = 'meta-llama/Llama-3.3-70B-Instruct'\n",
+    "try:\n",
+    "    llm = ChatOpenAI(model=model, base_url=base_url, api_key=access_token)\n",
+    "    print(f\"Successfully loaded model: {model} from {base_url}\")\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"Error with loading {model}\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dc913a05-7962-4ea3-acaa-9151298fd06a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "what is the weather in sf\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  get_weather (chatcmpl-tool-3eb1c6dfe4f448e9a471cc95937e18cf)\n",
+      " Call ID: chatcmpl-tool-3eb1c6dfe4f448e9a471cc95937e18cf\n",
+      "  Args:\n",
+      "    city: sf\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: get_weather\n",
+      "\n",
+      "It's always sunny in sf\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I'm just kidding, I don't have have access to real-time weather information. The function call I provided earlier is the correct format for getting the weather in San Francisco using the `get_weather` function.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Using pre-built ReAct agent from LangGraph example: https://langchain-ai.github.io/langgraph/how-tos/create-react-agent/\n",
+    "from typing import Literal\n",
+    "from langchain_core.tools import tool\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "@tool\n",
+    "def get_weather(city: Literal[\"nyc\", \"sf\"]):\n",
+    "    \"\"\"Use this to get weather information.\"\"\"\n",
+    "    if city == \"nyc\":\n",
+    "        return \"It might be cloudy in nyc\"\n",
+    "    elif city == \"sf\":\n",
+    "        return \"It's always sunny in sf\"\n",
+    "    else:\n",
+    "        raise AssertionError(\"Unknown city\")\n",
+    "\n",
+    "# Define the tools and graph\n",
+    "\n",
+    "tools = [get_weather]\n",
+    "weather_graph = create_react_agent(llm, tools=tools)\n",
+    "\n",
+    "def print_stream(stream):\n",
+    "    for s in stream:\n",
+    "        message = s[\"messages\"][-1]\n",
+    "        if isinstance(message, tuple):\n",
+    "            print(message)\n",
+    "        else:\n",
+    "            message.pretty_print()\n",
+    "            \n",
+    "inputs = {\"messages\": [(\"user\", \"what is the weather in sf\")],}\n",
+    "print_stream(weather_graph.stream(inputs, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a8cacd2b-2e22-45f1-9c08-2f50cb3b81c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture --no-stderr\n",
+    "%pip install pubchempy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "07d33242-ff4b-4d83-8fa0-d282e09ed429",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "what is SMILES string of Carbon Dioxide?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  molecule_name_to_smiles (chatcmpl-tool-4e7c9455b29c4ebea7bc66946dee6317)\n",
+      " Call ID: chatcmpl-tool-4e7c9455b29c4ebea7bc66946dee6317\n",
+      "  Args:\n",
+      "    name: Carbon Dioxide\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: molecule_name_to_smiles\n",
+      "\n",
+      "C(=O)=O\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The SMILES string for Carbon Dioxide is \"C(=O)=O\".\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "@tool\n",
+    "def molecule_name_to_smiles(name: str) -> str:\n",
+    "    \"\"\"Convert a molecule name SMILES format.\n",
+    "\n",
+    "    Args:\n",
+    "        name (str): molecule name.\n",
+    "\n",
+    "    Returns:\n",
+    "        str: SMILES string.\n",
+    "    \"\"\"\n",
+    "    import pubchempy\n",
+    "    return pubchempy.get_compounds(str(name), \"name\")[0].canonical_smiles\n",
+    "\n",
+    "tools = [molecule_name_to_smiles]\n",
+    "chem_graph = create_react_agent(llm, tools=tools)\n",
+    "\n",
+    "def print_stream(stream):\n",
+    "    for s in stream:\n",
+    "        message = s[\"messages\"][-1]\n",
+    "        if isinstance(message, tuple):\n",
+    "            print(message)\n",
+    "        else:\n",
+    "            message.pretty_print()\n",
+    "            \n",
+    "inputs = {\"messages\": [(\"user\", \"what is SMILES string of Carbon Dioxide?\")]}\n",
+    "print_stream(chem_graph.stream(inputs, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3d286475-67b3-4b87-8652-62edca987bf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "what is SMILES string of 1-ethyl-3-(1-naphthalen-2-ylethenylamino)thiourea?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  molecule_name_to_smiles (chatcmpl-tool-99e85a4a83164f14809ce1e2d4e1224b)\n",
+      " Call ID: chatcmpl-tool-99e85a4a83164f14809ce1e2d4e1224b\n",
+      "  Args:\n",
+      "    name: 1-ethyl-3-(1-naphthalen-2-ylethenylamino)thiourea\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: molecule_name_to_smiles\n",
+      "\n",
+      "CCNC(=S)NNC(=C)C1=CC2=CC=CC=C2C=C1\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The SMILES string of 1-ethyl-3-(1-naphthalen-2-ylethenylamino)thiourea is CCNC(=S)NNC(=C)C1=CC2=CC=CC=C2C=C1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "inputs = {\"messages\": [(\"user\", \"what is SMILES string of 1-ethyl-3-(1-naphthalen-2-ylethenylamino)thiourea?\")]}\n",
+    "print_stream(chem_graph.stream(inputs, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "089badb7-3f28-46d4-a342-e9c894327271",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sample_agent.ipynb
+++ b/sample_agent.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6af6c02e-d572-4744-b056-e3787ebfea30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture --no-stderr\n",
+    "%pip install -U langgraph langchain-openai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "3e49f6ec-f4d9-418d-bd37-4661e41293bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully loaded model: meta-llama/Meta-Llama-3.1-70B-Instruct from https://data-portal-dev.cels.anl.gov/resource_server/sophia/vllm/v1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from inference_auth_token import get_access_token\n",
+    "\n",
+    "access_token = get_access_token()\n",
+    "base_url=\"https://data-portal-dev.cels.anl.gov/resource_server/sophia/vllm/v1\"\n",
+    "model ='meta-llama/Meta-Llama-3.1-70B-Instruct'\n",
+    "\n",
+    "try:\n",
+    "    llm = ChatOpenAI(model=model, base_url=base_url, api_key=access_token)\n",
+    "    print(f\"Successfully loaded model: {model} from {base_url}\")\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(f\"Error with loading {model}\")\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc913a05-7962-4ea3-acaa-9151298fd06a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using pre-built ReAct agent from LangGraph example: https://langchain-ai.github.io/langgraph/how-tos/create-react-agent/\n",
+    "from typing import Literal\n",
+    "from langchain_core.tools import tool\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "@tool\n",
+    "def get_weather(city: Literal[\"nyc\", \"sf\"]):\n",
+    "    \"\"\"Use this to get weather information.\"\"\"\n",
+    "    if city == \"nyc\":\n",
+    "        return \"It might be cloudy in nyc\"\n",
+    "    elif city == \"sf\":\n",
+    "        return \"It's always sunny in sf\"\n",
+    "    else:\n",
+    "        raise AssertionError(\"Unknown city\")\n",
+    "\n",
+    "# Define the tools and graph\n",
+    "\n",
+    "tools = [get_weather]\n",
+    "weather_graph = create_react_agent(llm, tools=tools)\n",
+    "\n",
+    "def print_stream(stream):\n",
+    "    for s in stream:\n",
+    "        message = s[\"messages\"][-1]\n",
+    "        if isinstance(message, tuple):\n",
+    "            print(message)\n",
+    "        else:\n",
+    "            message.pretty_print()\n",
+    "            \n",
+    "inputs = {\"messages\": [(\"user\", \"what is the weather in sf\")]}\n",
+    "print_stream(weather_graph.stream(inputs, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "a8cacd2b-2e22-45f1-9c08-2f50cb3b81c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting pubchempy\n",
+      "  Using cached pubchempy-1.0.4-py3-none-any.whl\n",
+      "Installing collected packages: pubchempy\n",
+      "Successfully installed pubchempy-1.0.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install pubchempy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07d33242-ff4b-4d83-8fa0-d282e09ed429",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "what is SMILES string of Carbon Dioxide?\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_core.tools import tool\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "@tool\n",
+    "def molecule_name_to_smiles(name: str) -> str:\n",
+    "    \"\"\"Convert a molecule name SMILES format.\n",
+    "\n",
+    "    Args:\n",
+    "        name (str): molecule name.\n",
+    "\n",
+    "    Returns:\n",
+    "        str: SMILES string.\n",
+    "    \"\"\"\n",
+    "    return pubchempy.get_compounds(str(name), \"name\")[0].canonical_smiles\n",
+    "\n",
+    "tools = [molecule_name_to_smiles]\n",
+    "chem_graph = create_react_agent(llm, tools=tools)\n",
+    "\n",
+    "def print_stream(stream):\n",
+    "    for s in stream:\n",
+    "        message = s[\"messages\"][-1]\n",
+    "        if isinstance(message, tuple):\n",
+    "            print(message)\n",
+    "        else:\n",
+    "            message.pretty_print()\n",
+    "            \n",
+    "inputs = {\"messages\": [(\"user\", \"what is SMILES string of Carbon Dioxide?\")]}\n",
+    "print_stream(chem_graph.stream(inputs, stream_mode=\"values\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d286475-67b3-4b87-8652-62edca987bf0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a Jupyter notebook demonstrating how to deploy LangGraph-based LLM agents using models hosted on the ALCF inference endpoints. The notebook includes:

- An agent with a simple get_weather tool.
- An agent with a custom tool that can convert molecule names to SMILES strings using.

This serves as a minimal example for building tool-using agents with ALCF endpoints