### PR TITLE
support refresh tokens and configurable tokens.json storage

### DIFF
--- a/inference_auth_token.py
+++ b/inference_auth_token.py
@@ -28,12 +28,14 @@ class DomainBasedErrorHandler:
 
 
 # Get refresh authorizer object
-def get_auth_object(force=False, do_refresh=False):
+def get_auth_object(force=False, do_refresh=False, tokens_path=TOKENS_PATH):
     """
     Create a Globus UserApp with the inference service scope
     and trigger the authentication process. If authentication
     has already happened, existing tokens will be reused.
     """
+
+    tokens_json = globus_sdk.token_storage.JSONTokenStorage(tokens_path)
 
     # Create Globus user application
     app = globus_sdk.UserApp(
@@ -42,7 +44,8 @@ def get_auth_object(force=False, do_refresh=False):
         scope_requirements={GATEWAY_CLIENT_ID: [GATEWAY_SCOPE]},
         config=globus_sdk.GlobusAppConfig(
             request_refresh_tokens=True,
-            token_validation_error_handler=DomainBasedErrorHandler()
+            token_validation_error_handler=DomainBasedErrorHandler(),
+            token_storage=tokens_json
         ),
     )
 
@@ -53,7 +56,6 @@ def get_auth_object(force=False, do_refresh=False):
     # Authenticate using your Globus account or reuse existing tokens
     auth = app.get_authorizer(GATEWAY_CLIENT_ID)
     if do_refresh is True:
-        tokens_json = globus_sdk.token_storage.JSONTokenStorage(TOKENS_PATH)
         glob_auth_cli = globus_sdk.NativeAppAuthClient(AUTH_CLIENT_ID)
         authorizer = globus_sdk.RefreshTokenAuthorizer(
                        auth.refresh_token,
@@ -65,9 +67,9 @@ def get_auth_object(force=False, do_refresh=False):
     return auth
 
 
-def get_refresh_token():
+def get_refresh_token(tokens_path=TOKENS_PATH):
     # Get authorizer object and authenticate if need be
-    auth = get_auth_object(force=False, do_refresh=True)
+    auth = get_auth_object(force=False, do_refresh=True, tokens_path=tokens_path)
 
     # Make sure the stored access token if valid, and refresh otherwise
     auth.ensure_valid_token()
@@ -77,7 +79,7 @@ def get_refresh_token():
 
 
 # Get access token
-def get_access_token():
+def get_access_token(tokens_path=TOKENS_PATH):
     """
     Load existing tokens, refresh the access token if necessary,
     and return the valid access token. If there is no token stored
@@ -86,7 +88,7 @@ def get_access_token():
     """
 
     # Get authorizer object and authenticate if need be
-    auth = get_auth_object(force=False)
+    auth = get_auth_object(force=False, tokens_path=tokens_path)
 
     # Make sure the stored access token if valid, and refresh otherwise
     auth.ensure_valid_token()
@@ -96,7 +98,7 @@ def get_access_token():
 
 
 # Get time until token expiration
-def get_time_until_token_expiration(units="seconds"):
+def get_time_until_token_expiration(units="seconds", tokens_path=TOKENS_PATH):
     """
     Returns the time until the access token expires, in units of
     seconds, minutes, or hours. Negative times reveal that the token
@@ -104,7 +106,7 @@ def get_time_until_token_expiration(units="seconds"):
     """
 
     # Get authorizer object
-    auth = get_auth_object(force=False)
+    auth = get_auth_object(force=False, tokens_path=tokens_path)
 
     # Gather the time difference between now and the expiration time (both Unix timestamps)
     now = time.time()

--- a/inference_auth_token.py
+++ b/inference_auth_token.py
@@ -1,5 +1,6 @@
 import globus_sdk
 from globus_sdk.login_flows import LocalServerLoginFlowManager # Needed to access globus_sdk.gare
+from globus_sdk.token_storage import JSONTokenStorage
 import os.path
 import time
 
@@ -35,7 +36,7 @@ def get_auth_object(force=False, do_refresh=False, tokens_path=TOKENS_PATH):
     has already happened, existing tokens will be reused.
     """
 
-    tokens_json = globus_sdk.token_storage.JSONTokenStorage(tokens_path)
+    tokens_json = JSONTokenStorage(tokens_path)
 
     # Create Globus user application
     app = globus_sdk.UserApp(


### PR DESCRIPTION
## Summary of Changes

These few simple changes support a couple of features that I think are relevant for supporting services that would use auth gateway to the inference clusters:
* support for refresh tokens
* support for configurable paths to `tokens.json` token storage

Below is example usage with before and after artifacts of the refresh token being updated.
```
# Original State
80d4ad31a4f7d0fff3887d9bd08acbd5  .globus/app/58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb9
44/inference_app/tokens.json
-rw------- 1 user1 anonymous_group 970 Jan 30 09:29 .globus/app/58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb944/inference_app/tokens.json

# python get_refresh_tokens() call
$ python
Python 3.11.14 (main, Oct 10 2025, 08:54:03) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import alcf_inference_auth as aia
>>> tokens_json = '/tmp/GARBAGE/tokens.json'
>>> token_do_not_print = aia.get_refresh_token(tokens_path=tokens_json)
>>>

# Modified State (after the get_refresh_tokens() call)
1923c5b7ee18d93e4c6b4be50127f175  .globus/app/58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb9
44/inference_app/tokens.json
-rw------- 1 user1 anonymous_group 970 Jan 30 09:51 .globus/app/58fdd3bc-e1c3-4ce5-80ea-8d
6b87cfb944/inference_app/tokens.json
```

the `md5sum` and `modified timestamp` of the `tokens.json` reveals the refresh occurred.

## Requirements
* `globus_sdk v4`